### PR TITLE
Autograder supporting *.js files

### DIFF
--- a/prehook_lib.py
+++ b/prehook_lib.py
@@ -18,14 +18,14 @@ class ImportFixer:
             rf'my-gdrive\(["\'](.*-{name}\.arr)["\']\)',
             rf'file("{rel_loc}/{filename}")'
             if filename else rf'file("{rel_loc}/\1")', self.content)
-        OLD_DOCDIFF_IMPORT="gdrive-js(\"docdiff_qtm-validation.js\", \"11H5gJQtW9TJaiFkWw51fR4_oIibmLr7X\")"
-        NEW_DOCDIFF_IMPORT="shared-gdrive(\"docdiff_qtm-validation.arr\", \"12O---8ZF_VkukhEDGK63Z7hSvDf_PhEW\")"
-        self.content = self.content.replace(OLD_DOCDIFF_IMPORT, NEW_DOCDIFF_IMPORT)
 
     def finalize(self):
         self.content = re.sub(r'shared-gdrive\(["\'](.*?)["\'].*?\n?.*?\)',
                               rf'file("{self.rel_stencil_dir}/\1")',
                               self.content, re.M)
+        self.content = re.sub(r'gdrive-js\(["\'](.*?)["\'].*?\n?.*?\)',
+                                rf'js-file("{self.rel_stencil_dir}/\1")',
+                                self.content, re.M)
         with open(self.target_path, 'w', encoding="utf-8") as f:
             f.write(self.content)
 

--- a/prehook_lib.py
+++ b/prehook_lib.py
@@ -23,9 +23,9 @@ class ImportFixer:
         self.content = re.sub(r'shared-gdrive\(["\'](.*?)["\'].*?\n?.*?\)',
                               rf'file("{self.rel_stencil_dir}/\1")',
                               self.content, re.M)
-        self.content = re.sub(r'gdrive-js\(["\'](.*?)["\'].*?\n?.*?\)',
-                                rf'js-file("{self.rel_stencil_dir}/\1")',
-                                self.content, re.M)
+        self.content = re.sub(r'gdrive-js\(["\'](.*?)\.js["\'].*?\n?.*?\)',
+                              rf'file("{self.rel_stencil_dir}/\1.arr")',
+                              self.content, re.M)
         with open(self.target_path, 'w', encoding="utf-8") as f:
             f.write(self.content)
 


### PR DESCRIPTION
The validation.arr file must be in stencil, but we should also make sure it isn't included in the Examplar version.